### PR TITLE
Add realistic dashboard

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,17 @@
 import React from 'react';
 import Sidebar from './components/Sidebar';
+import Dashboard from './components/Dashboard';
+import { metrics, recentOrders } from './data/dashboardData';
 import './App.css'; // Assuming a basic CSS file for styling
+
+const sales = [10, 20, 30, 28, 45, 40, 60];
 
 function App() {
   return (
     <div className="App">
       <Sidebar />
       <main style={{ marginLeft: '240px', padding: '20px' }}> {/* Adjust marginLeft to accommodate sidebar width */}
-        <h1>Main Content</h1>
-        <p>This is where the main application content will go.</p>
+        <Dashboard metrics={metrics} orders={recentOrders} sales={sales} />
       </main>
     </div>
   );

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1,0 +1,25 @@
+"use client";
+import React from 'react';
+import { Box, Grid, Typography } from '@mui/material';
+import StatsGrid from './StatsGrid';
+import RecentOrders from './RecentOrders';
+import SalesChart from './SalesChart';
+
+const Dashboard = ({ metrics = [], orders = [], sales = [] }) => (
+  <Box sx={{ p: 2 }}>
+    <Typography variant="h5" sx={{ mb: 2 }}>
+      Dashboard Overview
+    </Typography>
+    <StatsGrid metrics={metrics} />
+    <Grid container spacing={2} sx={{ mt: 1 }}>
+      <Grid item xs={12} md={8}>
+        <SalesChart data={sales} />
+      </Grid>
+      <Grid item xs={12} md={4}>
+        <RecentOrders orders={orders} />
+      </Grid>
+    </Grid>
+  </Box>
+);
+
+export default Dashboard;

--- a/src/components/Dashboard.test.js
+++ b/src/components/Dashboard.test.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import Dashboard from './Dashboard';
+
+// Mock ResizeObserver for MUI components
+global.ResizeObserver = require('resize-observer-polyfill');
+
+const theme = createTheme();
+const renderWithTheme = (ui) => render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
+
+describe('Dashboard Component', () => {
+  const metrics = [
+    { title: 'Users', value: 100, change: 3 },
+    { title: 'Orders', value: 50, change: -1 },
+  ];
+  const orders = [
+    { id: 1, customer: 'Jane', amount: 10, status: 'Shipped', date: '2025-06-01' },
+  ];
+  const sales = [1, 2, 3];
+
+  test('renders metric titles and values', () => {
+    renderWithTheme(<Dashboard metrics={metrics} orders={orders} sales={sales} />);
+    metrics.forEach(({ title, value }) => {
+      expect(screen.getByText(title)).toBeInTheDocument();
+      expect(screen.getByText(value)).toBeInTheDocument();
+    });
+  });
+
+  test('renders recent orders table', () => {
+    renderWithTheme(<Dashboard metrics={metrics} orders={orders} sales={sales} />);
+    expect(screen.getByText('Recent Orders')).toBeInTheDocument();
+    expect(screen.getByRole('row')).toBeInTheDocument();
+  });
+});

--- a/src/components/RecentOrders.js
+++ b/src/components/RecentOrders.js
@@ -1,0 +1,35 @@
+"use client";
+import React from 'react';
+import { Table, TableHead, TableBody, TableRow, TableCell, Paper, Typography } from '@mui/material';
+
+const RecentOrders = ({ orders }) => (
+  <Paper sx={{ p: 2 }}>
+    <Typography variant="h6" sx={{ mb: 1 }}>
+      Recent Orders
+    </Typography>
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell>ID</TableCell>
+          <TableCell>Customer</TableCell>
+          <TableCell>Date</TableCell>
+          <TableCell align="right">Amount</TableCell>
+          <TableCell>Status</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {orders.map((o) => (
+          <TableRow key={o.id} role="row">
+            <TableCell>{o.id}</TableCell>
+            <TableCell>{o.customer}</TableCell>
+            <TableCell>{o.date}</TableCell>
+            <TableCell align="right">${o.amount}</TableCell>
+            <TableCell>{o.status}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  </Paper>
+);
+
+export default RecentOrders;

--- a/src/components/SalesChart.js
+++ b/src/components/SalesChart.js
@@ -1,0 +1,30 @@
+"use client";
+import React from 'react';
+import { Paper, Box, Typography } from '@mui/material';
+
+// Simple sparkline chart using SVG
+const SalesChart = ({ data }) => {
+  const max = Math.max(...data);
+  const points = data
+    .map((v, i) => `${(i / (data.length - 1)) * 100},${100 - (v / max) * 100}`)
+    .join(' ');
+  return (
+    <Paper sx={{ p: 2 }}>
+      <Typography variant="h6" sx={{ mb: 1 }}>
+        Sales Trend
+      </Typography>
+      <Box sx={{ width: '100%', height: 100 }}>
+        <svg viewBox="0 0 100 100" preserveAspectRatio="none" width="100%" height="100%">
+          <polyline
+            fill="none"
+            stroke="#1976d2"
+            strokeWidth="2"
+            points={points}
+          />
+        </svg>
+      </Box>
+    </Paper>
+  );
+};
+
+export default SalesChart;

--- a/src/components/StatsGrid.js
+++ b/src/components/StatsGrid.js
@@ -1,0 +1,29 @@
+"use client";
+import React from 'react';
+import { Grid, Paper, Typography, Box } from '@mui/material';
+
+const StatCard = ({ title, value, change }) => (
+  <Paper sx={{ p: 2 }} elevation={1} role="article">
+    <Typography variant="subtitle2" color="text.secondary">
+      {title}
+    </Typography>
+    <Typography variant="h6" sx={{ mb: 1 }}>
+      {value}
+    </Typography>
+    <Box sx={{ color: change >= 0 ? 'success.main' : 'error.main' }}>
+      {change >= 0 ? '+' : ''}{change}%
+    </Box>
+  </Paper>
+);
+
+const StatsGrid = ({ metrics }) => (
+  <Grid container spacing={2}>
+    {metrics.map((m, idx) => (
+      <Grid item xs={12} sm={6} md={3} key={idx}>
+        <StatCard {...m} />
+      </Grid>
+    ))}
+  </Grid>
+);
+
+export default StatsGrid;

--- a/src/data/dashboardData.js
+++ b/src/data/dashboardData.js
@@ -1,0 +1,13 @@
+export const metrics = [
+  { title: 'Users', value: 1200, change: 5 },
+  { title: 'Orders', value: 420, change: -2 },
+  { title: 'Revenue', value: 15800, change: 7 },
+  { title: 'Tickets', value: 36, change: 12 },
+];
+
+export const recentOrders = [
+  { id: 5012, customer: 'Alice Johnson', amount: 240, status: 'Shipped', date: '2025-06-01' },
+  { id: 5013, customer: 'Bob Smith', amount: 125, status: 'Processing', date: '2025-06-02' },
+  { id: 5014, customer: 'Carlos Diaz', amount: 600, status: 'Delivered', date: '2025-06-03' },
+  { id: 5015, customer: 'Diana Wilson', amount: 80, status: 'Cancelled', date: '2025-06-04' },
+];


### PR DESCRIPTION
## Summary
- build out Dashboard with StatsGrid, SalesChart, and RecentOrders
- provide sample data and wire Dashboard in App
- expand tests for new Dashboard features

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68400688c10483229be6ba2bfe855347