### PR TITLE
Add LangChain setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv/
+__pycache__/

--- a/langchain_setup/README.md
+++ b/langchain_setup/README.md
@@ -1,0 +1,25 @@
+# LangChain Setup
+
+This folder contains a minimal setup for using [LangChain](https://python.langchain.com) within this repository.
+
+## Installation
+
+Create a virtual environment (optional) and install the dependencies:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Usage
+
+Set your OpenAI API key in the environment and run the example script:
+
+```bash
+export OPENAI_API_KEY=your-key-here
+python langchain_example.py
+```
+
+The script will make a simple completion request using LangChain's `OpenAI` wrapper.
+

--- a/langchain_setup/langchain_example.py
+++ b/langchain_setup/langchain_example.py
@@ -1,0 +1,17 @@
+import os
+
+from langchain.llms import OpenAI
+
+
+def main():
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise EnvironmentError("Please set the OPENAI_API_KEY environment variable.")
+
+    llm = OpenAI(api_key=api_key)
+    response = llm("Hello, world!")
+    print(response)
+
+
+if __name__ == "__main__":
+    main()

--- a/langchain_setup/requirements.txt
+++ b/langchain_setup/requirements.txt
@@ -1,0 +1,2 @@
+langchain
+openai


### PR DESCRIPTION
## Summary
- add `.gitignore` for virtual environments and caches
- create `langchain_setup` folder with an example Python script
- document installation and usage in `langchain_setup/README.md`
- specify requirements for LangChain

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68400abec1f88322b88ffcfe16826aa2